### PR TITLE
Add problem matchers for panic and test failure

### DIFF
--- a/.matchers/rust.json
+++ b/.matchers/rust.json
@@ -1,7 +1,7 @@
 {
     "problemMatcher": [
         {
-            "owner": "rust",
+            "owner": "rust-diagnostic",
             "pattern": [
                 {
                     "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
@@ -14,6 +14,27 @@
                     "file": 2,
                     "line": 3,
                     "column": 4
+                }
+            ]
+        },
+        {
+            "owner": "rust-panic",
+            "pattern": [
+                {
+                    "regexp": "^(thread\\s+'[^']+'\\s+panicked\\s+at\\s+'[^']+(?:'|$))(?:,\\s+([^/\\\\][^:]+):(\\d+):(\\d+))?",
+                    "file": 2,
+                    "line": 3,
+                    "column": 4,
+                    "message": 1
+                }
+            ]
+        },
+        {
+            "owner": "rust-test-failure",
+            "pattern": [
+                {
+                    "regexp": "^(test\\s+\\w+\\s+\\.{3}\\s+FAILED)",
+                    "message": 1
                 }
             ]
         }


### PR DESCRIPTION
### Backwards compatibility

This is a breaking change as it'd break:

```sh
echo "::remove-matcher owner=rust::"
```