### PR TITLE
Version 1.1.0 uses Node16 (instead of Node12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         env:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci
       - run: npm run lint
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade action.yml to use Node16 (replacing Node12)
 - Bump version number to 1.1.0
+- See if another update triggers good stuff
 
 ## [1.0.3] - 2019-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade action.yml to use Node16 (replacing Node12)
 - Bump version number to 1.1.0
 - See if another update triggers good stuff
+- Trigger another update
 
 ## [1.0.3] - 2019-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2022-11-29
+
+### Fixed
+
+- Upgrade action.yml to use Node16 (replacing Node12)
+- Bump version number to 1.1.0
+
 ## [1.0.3] - 2019-11-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2024-06-07
+
+### Fixed
+
+- Upgrade action.yml to use Node20 (replacing Node16
+- Update version number to 1.1.1 in _package.json_
+- Testing: commit the change, see if it triggers an update in
+[PRQL repo](https://github.com/PRQL/prql)
+
 ## [1.1.0] - 2022-11-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -123,10 +123,15 @@ This Action is distributed under the terms of the MIT license, see [LICENSE](htt
 
 ## Contribute and support
 
-Any contributions are welcomed!
+This is a fork of the original repo at [https://github.com/actions-rs/cargo](https://github.com/actions-rs/cargo)
 
-If you want to report a bug or have a feature request,
-check the [Contributing guide](https://github.com/actions-rs/.github/blob/master/CONTRIBUTING.md).
+It is maintained from time to time to keep the Node.js version up to date.
+Pointers to well-supported alternatives are welcome.
 
-You can also support author by funding the ongoing project work,
-see [Sponsoring](https://actions-rs.github.io/#sponsoring).
+~~Any contributions are welcomed!~~
+
+~~If you want to report a bug or have a feature request,
+check the [Contributing guide](https://github.com/actions-rs/.github/blob/master/CONTRIBUTING.md).~~
+
+~~You can also support author by funding the ongoing project work,
+see [Sponsoring](https://actions-rs.github.io/#sponsoring).~~

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -21,4 +21,4 @@ inputs:
 runs:
   using: 'node20'
   main: 'dist/index.js'
-  version: '1.1.1'
+

--- a/action.yml
+++ b/action.yml
@@ -21,3 +21,4 @@ inputs:
 runs:
   using: 'node20'
   main: 'dist/index.js'
+  version: '1.1.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rust-cargo",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "private": false,
     "description": "Run cargo command",
     "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rust-cargo",
-    "version": "1.1.1",
+    "version": "1.1.0",
     "private": false,
     "description": "Run cargo command",
     "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rust-cargo",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": false,
     "description": "Run cargo command",
     "main": "lib/main.js",


### PR DESCRIPTION
Github Actions will stop working with Node12 sometime next year (2023). This PR updates the `action.yml` file to use `node16` and updates `package.json` to version 1.1.0